### PR TITLE
fix(test): use schema-compliant id+categories in usage unit spec (unblocks Release)

### DIFF
--- a/.github/workflows/governance-hash.yml
+++ b/.github/workflows/governance-hash.yml
@@ -22,8 +22,10 @@ jobs:
           CUR=$(echo '{"jsonrpc":"2.0","id":1,"method":"instructions/governanceHash"}' | node dist/server/index-server.js | jq -r '.result.governanceHash')
           echo "hash=$CUR" >> $GITHUB_OUTPUT
       - name: Checkout base for comparison
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin "$BASE_REF" --depth=1
           git checkout FETCH_HEAD
           npm ci
           npm run build

--- a/src/tests/unit/indexContext.usage.unit.spec.ts
+++ b/src/tests/unit/indexContext.usage.unit.spec.ts
@@ -18,7 +18,7 @@ import { enableFeature } from '../../services/features';
 
 // Minimal instruction factory
 function makeEntry(id: string){
-  return { id, title: `Title ${id}`, body: 'Sample body', version: '1.0.0', categories: ['scope:workspace:unit', 'type:test'] } as any;
+  return { id, title: `Title ${id}`, body: 'Sample body', version: '1.0.0', categories: ['scope-workspace-unit', 'type-test'] } as any;
 }
 
 describe('indexContext usage + materialization (P0)', () => {
@@ -61,7 +61,7 @@ describe('indexContext usage + materialization (P0)', () => {
   });
 
   it('incrementUsage establishes firstSeenTs + lastUsedAt and increments monotonically (no double increment)', () => {
-  const id = 'unit_usageMonotonic_' + Date.now();
+  const id = 'unit_usage_monotonic_' + Date.now();
   const filePath = path.join(INSTR_DIR, id + '.json');
   if(fs.existsSync(filePath)) fs.unlinkSync(filePath);
     writeEntry(makeEntry(id));


### PR DESCRIPTION
Mirrors jagilber-dev/index-server#238.

The Release workflow's Unit test gate (npm run test:unit) fails with:
```n FAIL  src/tests/unit/indexContext.usage.unit.spec.ts (2 tests)
Error: Pre-write loader-schema validation failed
  /id must match pattern "^[a-z0-9](?:[a-z0-9-_]{0,118}[a-z0-9])?\$"
  /categories/0 must match pattern "^[a-z0-9][a-z0-9-_]{0,48}\$"
```nblocking publish jobs. The spec is in scripts/slow-tests.mjs so test:fast (build-test PR CI) skipped it.

Fix: lowercase id segment, hyphen-separated categories. Verified locally upstream.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>