### PR TITLE
Publish v1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [1.28.1] - 2026-05-05
+
+### Fixed
+
+- **Setup wizard package entrypoint**: fixed `npx -y @jagilber-org/index-server@latest --setup` by pointing the packed CLI launcher at `scripts/build/setup-wizard.mjs`.
+- **Release validation**: ensured PR and release unit-test paths emit `test-results/junit.xml`, restored public governance utilities in publish branches, and made duplicate MCP Registry publishes idempotent.
+- **Public CI gates**: stabilized merge-only log hygiene and GGShield quota handling so public `main` remains green after release PR merges.
+
 ### Added
 
 - **Release workflow**: added `scripts/Invoke-ReleaseWorkflow.ps1` as the canonical release/publish front door. It loads `.env`, resolves tag/remote/clean-room defaults, runs release preflight checks, optionally pushes and verifies the internal branch/tags, waits for internal GitHub Actions checks, prepares the clean-room mirror copy, and either prints or explicitly invokes the human-only public mirror delivery path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jagilber-org/index-server",
-  "version": "1.27.1",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jagilber-org/index-server",
-      "version": "1.27.1",
+      "version": "1.28.1",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jagilber-org/index-server",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "mcpName": "io.github.jagilber-org/index-server",
   "description": "MCP instruction indexing server with search, CRUD, validation, and cross-repo knowledge promotion.",
   "publishConfig": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/jagilber-org/index-server",
     "source": "github"
   },
-  "version": "1.28.0",
+  "version": "1.28.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jagilber-org/index-server",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- bump public package and MCP manifest versions to 1.28.1
- include release notes for the setup wizard, JUnit, release, and public CI fixes

## Validation
- npm run check:version-parity
- npx vitest run --config vitest.config.ts src/tests/unit/npmPackReadiness.spec.ts
