### PR TITLE
Publish v1.28.12: scripts route 404 + smarter embeddings compute

### DIFF
--- a/.publish-manifest.json
+++ b/.publish-manifest.json
@@ -1,11 +1,11 @@
 {
-  "contentHash": "586baaa02685ecf74dad338db5a723515ff15eeb783ba89d1b745f100f969742",
-  "tag": "v1.28.11",
-  "commitSha": "450fd97282c408589af39bce50dba4a04545da8f",
-  "fileCount": 1188,
   "manifestVersion": 2,
-  "forbiddenArtifactCheck": "passed",
-  "preparedAt": "2026-05-08T01:44:45.1010821Z",
+  "preparedAt": "2026-05-08T03:13:38.4061921Z",
+  "commitSha": "c10e89a57a93d3648755f1715bee9a63216bb7e5",
+  "contentHash": "77d9439b2ed4126fc5fbb652d8214fe66a4e26a727d4e7a2e48aadb480e236dd",
   "piiScanPassed": true,
-  "sourceRepo": "index-server"
+  "forbiddenArtifactCheck": "passed",
+  "sourceRepo": "index-server",
+  "tag": "v1.28.12",
+  "fileCount": 1188
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [1.28.12] - 2026-05-07
+
+### Fixed
+
+- **Dashboard `/api/scripts/:name` 404**: client wrapper scripts (`index-server-client.ps1`, `index-server-client.sh`) are now packaged in the npm tarball and the route resolves them from the installed package directory instead of `process.cwd()`. Previously every install returned `Script file not found on disk`.
+
+### Added
+
+- **Embeddings panel — Clear Cache button + smarter Compute**: new `POST /api/embeddings/reset` endpoint clears the cached embeddings (works for both JSON and SQLite stores). The Compute button now pre-checks status and: warns when the model will download (~25MB), short-circuits when embeddings are already up to date with a confirm prompt, and surfaces an honest `cacheHit` / `computed` / `reused` summary instead of always reporting "Computed N embeddings". The old `Reset` button was renamed to `Reset View` to clarify that it only resets pan/zoom.
+
 ## [1.28.2] - 2026-05-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jagilber-org/index-server",
-  "version": "1.28.11",
+  "version": "1.28.12",
   "mcpName": "io.github.jagilber-org/index-server",
   "description": "MCP instruction indexing server with search, CRUD, validation, and cross-repo knowledge promotion.",
   "publishConfig": {
@@ -16,6 +16,7 @@
     "!dist/tests/",
     "schemas/",
     "templates/",
+    "scripts/client/",
     "scripts/build/copy-dashboard-assets.mjs",
     "scripts/hooks/setup-hooks.cjs",
     "scripts/build/generate-certs.mjs",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/jagilber-org/index-server",
     "source": "github"
   },
-  "version": "1.28.11",
+  "version": "1.28.12",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jagilber-org/index-server",
-      "version": "1.28.11",
+      "version": "1.28.12",
       "transport": {
         "type": "stdio"
       }

--- a/src/dashboard/client/admin.html
+++ b/src/dashboard/client/admin.html
@@ -442,7 +442,8 @@
                             <div class="emb-controls">
                                 <button class="emb-btn" data-emb-action="compute">Compute</button>
                                 <button class="emb-btn" data-emb-action="load">Load</button>
-                                <button class="emb-btn" data-emb-action="reset">Reset</button>
+                                <button class="emb-btn" data-emb-action="reset" title="Reset pan/zoom view">Reset View</button>
+                                <button class="emb-btn" data-emb-action="clear" title="Clear cached embeddings (forces recompute on next Compute)">Clear Cache</button>
                                 <button class="emb-btn" id="emb-norm-btn" data-emb-action="norm">Norm</button>
                             </div>
                             <span id="emb-status" class="emb-status-text"></span>

--- a/src/dashboard/client/js/admin.embeddings.js
+++ b/src/dashboard/client/js/admin.embeddings.js
@@ -436,10 +436,76 @@
     }
   };
 
+  window.clearEmbeddingsCache = async function clearEmbeddingsCache() {
+    var statusEl = document.getElementById('emb-status');
+    var ok = window.confirm(
+      'Clear cached embeddings?\n\nNext Compute will rebuild them and download the embedding model if not already cached.'
+    );
+    if (!ok) return;
+    try {
+      if (statusEl) statusEl.textContent = 'Clearing embeddings cache…';
+      var res = await adminAuth.adminFetch('/api/embeddings/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clearModel: false }),
+      });
+      var data = await res.json().catch(function () { return {}; });
+      if (!res.ok) {
+        if (statusEl) statusEl.textContent = 'Clear failed: ' + (data.error || res.statusText);
+        return;
+      }
+      if (statusEl) statusEl.textContent = 'Cleared (embeddingsCleared=' + !!data.embeddingsCleared + '). Click Compute to rebuild.';
+      window.loadEmbeddingsStatus();
+    } catch (e) {
+      if (statusEl) statusEl.textContent = 'Clear failed: ' + e.message;
+    }
+  };
+
   window.computeEmbeddings = async function computeEmbeddings() {
     if (!canvas) init();
     var statusEl = document.getElementById('emb-status');
-    if (statusEl) statusEl.textContent = 'Computing embeddings (model download on first run)…';
+
+    // Pre-flight: fetch status so we can give the user actionable info.
+    var pre = null;
+    try {
+      var sres = await adminAuth.adminFetch('/api/embeddings/status');
+      if (sres.ok) pre = await sres.json();
+    } catch (_e) { void _e; }
+
+    if (pre && pre.success) {
+      if (pre.state === 'disabled') {
+        if (statusEl) statusEl.textContent = 'Embeddings are disabled. Set INDEX_SERVER_SEMANTIC_ENABLED=1 and restart.';
+        return;
+      }
+      if (pre.state === 'missing') {
+        if (statusEl) statusEl.textContent = 'Model is not cached and remote downloads are disabled (localOnly=true). Set INDEX_SERVER_SEMANTIC_LOCAL_ONLY=0 and restart, or pre-stage the model.';
+        return;
+      }
+      if (pre.state === 'ready') {
+        var ok = window.confirm(
+          'Embeddings are already up to date (' + (pre.embeddingsCount || 0) + ' cached, model=' + (pre.model || '?') + ').\n\nCompute will be a no-op unless the index has changed.\n\nProceed anyway?'
+        );
+        if (!ok) {
+          if (statusEl) statusEl.textContent = 'Cancelled. Use "Clear Cache" to force a full rebuild.';
+          return;
+        }
+      }
+      if (pre.state === 'will-download') {
+        var ok2 = window.confirm(
+          'Model "' + (pre.model || '?') + '" is not cached. Compute will download ~25MB to:\n\n' + (pre.cacheDir || '?') + '\n\nProceed?'
+        );
+        if (!ok2) {
+          if (statusEl) statusEl.textContent = 'Cancelled.';
+          return;
+        }
+        if (statusEl) statusEl.textContent = 'Downloading model + computing embeddings (this may take 30-60s)…';
+      } else if (statusEl) {
+        statusEl.textContent = 'Computing embeddings…';
+      }
+    } else if (statusEl) {
+      statusEl.textContent = 'Computing embeddings (model download on first run)…';
+    }
+
     try {
       var res = await adminAuth.adminFetch('/api/embeddings/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
       if (!res.ok) {
@@ -448,13 +514,20 @@
         if (err.hint) detail += ' — ' + err.hint;
         else if (err.message) detail += ' — ' + err.message;
         if (statusEl) statusEl.textContent = 'Error: ' + detail;
-        // Refresh banner so user sees the actionable state machine.
         window.loadEmbeddingsStatus();
         return;
       }
       var result = await res.json();
-      if (statusEl) statusEl.textContent = 'Computed ' + result.count + ' embeddings (' + result.model + ', ' + result.elapsedMs + 'ms). Loading visualization…';
-      // Auto-load the projection + refresh banner
+      if (statusEl) {
+        if (result.cacheHit) {
+          statusEl.textContent = 'Cache hit: ' + result.count + ' embeddings already current (no work done, ' + result.elapsedMs + 'ms). Use "Clear Cache" to force a rebuild.';
+        } else {
+          var summary = 'Computed ' + (result.computed != null ? result.computed : result.count) + ' new'
+            + (result.reused != null && result.reused > 0 ? ' (' + result.reused + ' reused)' : '')
+            + ' · model=' + result.model + ' · ' + result.elapsedMs + 'ms. Loading visualization…';
+          statusEl.textContent = summary;
+        }
+      }
       window.loadEmbeddingsStatus();
       await window.loadEmbeddings();
     } catch (e) {
@@ -472,6 +545,7 @@
       if (action === 'compute') window.computeEmbeddings();
       else if (action === 'load') window.loadEmbeddings();
       else if (action === 'reset') window.resetEmbeddingsView();
+      else if (action === 'clear') window.clearEmbeddingsCache();
       else if (action === 'norm') window.toggleNormColor();
     });
   }

--- a/src/dashboard/server/routes/embeddings.routes.ts
+++ b/src/dashboard/server/routes/embeddings.routes.ts
@@ -354,16 +354,49 @@ export function createEmbeddingsRoutes(embeddingPathOverride?: string, embedding
         });
       }
 
+      // Pre-flight: detect a no-op (full cache hit) so we can return a clearer
+      // signal to the dashboard instead of pretending we just computed N items.
+      const readiness = checkModelReadiness(sem.model, sem.cacheDir, sem.localOnly);
+      let preCached: { indexHash?: string; modelName?: string; entryHashes?: Record<string, string>; embeddings?: Record<string, number[]> } | null = null;
+      try {
+        if (embeddingStore) {
+          preCached = embeddingStore.load();
+        } else {
+          const file = embeddingPathOverride ?? sem.embeddingPath;
+          if (file && fs.existsSync(file)) {
+            preCached = JSON.parse(fs.readFileSync(file, 'utf8'));
+          }
+        }
+      } catch { /* tolerate */ }
+
+      const currentIds = new Set(state.list.map(i => i.id));
+      const cachedIds = preCached?.embeddings ? new Set(Object.keys(preCached.embeddings)) : new Set<string>();
+      const cachedHashes = preCached?.entryHashes ?? {};
+      const sameModel = preCached?.modelName === sem.model;
+      const sameIndex = preCached?.indexHash === state.hash;
+      const toCompute = state.list.filter(inst => {
+        if (!sameModel) return true;
+        const h = cachedHashes[inst.id];
+        return !h || h !== inst.sourceHash || !cachedIds.has(inst.id);
+      });
+      const fullHit = sameModel && sameIndex && toCompute.length === 0 && cachedIds.size > 0;
+
       const start = performance.now();
       const embeddings = await getInstructionEmbeddings(
         state.list, state.hash, sem.embeddingPath, sem.model, sem.cacheDir, sem.device, sem.localOnly
       );
       const elapsed = (performance.now() - start).toFixed(0);
       const count = Object.keys(embeddings).length;
+      const computed = fullHit ? 0 : toCompute.length;
+      const reused = count - computed;
 
       return res.json({
         success: true,
         count,
+        computed,
+        reused,
+        cacheHit: fullHit,
+        modelDownloaded: !readiness.cached, // best-effort: model wasn't cached before this call
         model: sem.model,
         device: sem.device,
         elapsedMs: Number(elapsed),
@@ -386,6 +419,49 @@ export function createEmbeddingsRoutes(embeddingPathOverride?: string, embedding
           ? 'The embedding model is not cached locally and remote downloads are disabled. ' +
             'Set INDEX_SERVER_SEMANTIC_LOCAL_ONLY=0 and restart, or pre-stage the model in INDEX_SERVER_SEMANTIC_CACHE_DIR.'
           : undefined,
+      });
+    }
+  });
+
+  // POST /embeddings/reset — clear cached embeddings (forces full recompute on next compute).
+  // Optionally clears the on-disk model cache so the next compute re-downloads the model.
+  router.post('/embeddings/reset', dashboardAdminAuth, async (req: Request, res: Response) => {
+    try {
+      const sem = getRuntimeConfig().semantic;
+      const clearModel = req.body && (req.body as { clearModel?: boolean }).clearModel === true;
+      let embeddingsCleared = false;
+      let modelCacheCleared = false;
+
+      // Clear embeddings cache (works for both JSON file and SQLite store).
+      if (embeddingStore) {
+        embeddingStore.save({ indexHash: '', modelName: '', entryHashes: {}, embeddings: {} });
+        embeddingsCleared = true;
+      } else {
+        const file = embeddingPathOverride ?? sem.embeddingPath;
+        if (file && fs.existsSync(file)) {
+          fs.rmSync(file, { force: true });
+          embeddingsCleared = true;
+        }
+      }
+
+      // Optionally clear the model cache directory to force a re-download.
+      if (clearModel && sem.cacheDir && fs.existsSync(sem.cacheDir)) {
+        fs.rmSync(sem.cacheDir, { recursive: true, force: true });
+        modelCacheCleared = true;
+      }
+
+      return res.json({
+        success: true,
+        embeddingsCleared,
+        modelCacheCleared,
+        embeddingPath: embeddingPathOverride ?? sem.embeddingPath,
+        cacheDir: sem.cacheDir,
+      });
+    } catch (err) {
+      return res.status(500).json({
+        success: false,
+        error: 'Failed to reset embeddings',
+        message: (err as Error).message,
       });
     }
   });

--- a/src/dashboard/server/routes/scripts.routes.ts
+++ b/src/dashboard/server/routes/scripts.routes.ts
@@ -57,30 +57,54 @@ export function createScriptsRoutes(): Router {
       return;
     }
 
-    try {
-      const scriptsDir = path.join(process.cwd(), 'scripts', 'dist');
-      const filePath = path.join(scriptsDir, meta.file); // nosemgrep: javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal -- path validated below via startsWith check
+    // Candidate dirs (first existing wins):
+    //  1. Installed package layout: <pkg-root>/scripts/client (resolved from __dirname = dist/dashboard/server/routes)
+    //  2. Installed package layout (alt): <pkg-root>/scripts/dist (legacy)
+    //  3. Repo dev layout: <cwd>/scripts/client
+    //  4. Repo dev layout (legacy): <cwd>/scripts/dist
+    const pkgRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const candidateDirs = [
+      path.join(pkgRoot, 'scripts', 'client'),
+      path.join(pkgRoot, 'scripts', 'dist'),
+      path.join(process.cwd(), 'scripts', 'client'),
+      path.join(process.cwd(), 'scripts', 'dist'),
+    ];
 
+    let content: string | undefined;
+    let lastErr: unknown;
+    for (const scriptsDir of candidateDirs) {
+      const filePath = path.join(scriptsDir, meta.file); // nosemgrep: javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal -- path validated below via startsWith check
       let resolved: string;
       try {
         resolved = validatePathContainment(path.resolve(filePath), scriptsDir); // nosemgrep: javascript.express.security.audit.express-path-join-resolve-traversal.express-path-join-resolve-traversal -- containment validated by shared helper
       } catch {
-        res.status(400).json({ error: 'Invalid script path' });
+        continue;
+      }
+      try {
+        content = await readFile(resolved, 'utf-8');
+        break;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+
+    try {
+      if (content === undefined) {
+        const message = lastErr instanceof Error ? lastErr.message : String(lastErr);
+        if (!lastErr || message.includes('ENOENT')) {
+          res.status(404).json({ error: `Script file not found on disk: ${name}` });
+        } else {
+          res.status(500).json({ error: `Failed to read script: ${message}` });
+        }
         return;
       }
-
-      const content = await readFile(resolved, 'utf-8');
       res.setHeader('Content-Type', meta.contentType);
       res.setHeader('Content-Disposition', `attachment; filename="${meta.file}"`);
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.send(content); // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- content served with Content-Type, Content-Disposition attachment, and X-Content-Type-Options: nosniff headers
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('ENOENT')) {
-        res.status(404).json({ error: `Script file not found on disk: ${name}` });
-      } else {
-        res.status(500).json({ error: `Failed to read script: ${message}` });
-      }
+      res.status(500).json({ error: `Failed to send script: ${message}` });
     }
   });
 


### PR DESCRIPTION
Mirror of internal commit c10e89a (v1.28.12).

## Fixed
- Dashboard /api/scripts/:name returned 404 'Script file not found on disk' on installs - resolve script files from the installed package dir rather than process.cwd, and ship scripts/client/ in the npm tarball.

## Added
- POST /api/embeddings/reset endpoint (admin) that clears cached embeddings for both JSON and SQLite stores.
- 'Clear Cache' button alongside (renamed) 'Reset View' in the Embeddings panel so the two distinct actions are obvious.
- Compute pre-flight: status check before submitting; aborts with actionable hint when the engine is disabled or the model is unavailable; confirms before model download or no-op cache hit.
- Compute response now reports cacheHit/computed/reused so the dashboard can show honest status.